### PR TITLE
Fix: Last Node of each node_chunk getting skipped

### DIFF
--- a/GraphTsetlinMachine/kernels.py
+++ b/GraphTsetlinMachine/kernels.py
@@ -549,7 +549,7 @@ code_evaluate = """
         __global__ void exchange_messages(
             int number_of_nodes,
             int *hypervectors,
-            int *global_clause_node_output,
+            unsigned int *global_clause_node_output,
             int node_index,
             int global_edge_index,
             int *number_of_graph_node_edges,
@@ -569,8 +569,8 @@ code_evaluate = """
 
                 int edge_index = global_edge_index;
                 for (int source_node = 0; source_node < number_of_nodes; ++source_node) {
-                    int source_node_chunk = source_node / INT_SIZE;
-                    int source_node_pos = source_node % INT_SIZE;
+                    unsigned int source_node_chunk = source_node / INT_SIZE;
+                    unsigned int source_node_pos = source_node % INT_SIZE;
                     
                     if ((global_clause_node_output[clause*NODE_CHUNKS + source_node_chunk] & (1 << source_node_pos)) > 0) { 
                         for (int i = 0; i < number_of_graph_node_edges[node_index + source_node]; ++i) {


### PR DESCRIPTION
The last node of every node_chunk was not sending any messages to its neighbours (in the exchange_messages kernel function), when number of nodes is greater than 32.

This was because the global_clause_node_output, source_node_chunk and source_node_pos where signed integers, so the if condition was evaluated to false, when the source_node_pos was the last node of the chunk. 

Making them unsigned fixes the problem.